### PR TITLE
Corrects depreciated method getIpAddress in the examples

### DIFF
--- a/disque-job-queue/src/test/java/DisqueBackedMailSenderTest.java
+++ b/disque-job-queue/src/test/java/DisqueBackedMailSenderTest.java
@@ -29,7 +29,7 @@ public class DisqueBackedMailSenderTest {
     @Before
     public void setup() {
         context("");
-        disqueClient = new DisqueClient(DisqueURI.create(container.getIpAddress(), container.getMappedPort(7711)));
+        disqueClient = new DisqueClient(DisqueURI.create(container.getContainerIpAddress(), container.getMappedPort(7711)));
         mockMailApiClient = mock(MailApiClient.class);
 
         service = new DisqueBackedMailSenderService(disqueClient, mockMailApiClient);

--- a/disque-job-queue/src/test/java/SingleDisqueInstanceTest.java
+++ b/disque-job-queue/src/test/java/SingleDisqueInstanceTest.java
@@ -26,7 +26,7 @@ public class SingleDisqueInstanceTest {
     @Before
     public void setup() {
         context("");
-        DisqueClient client = new DisqueClient(DisqueURI.create(container.getIpAddress(), container.getMappedPort(7711)));
+        DisqueClient client = new DisqueClient(DisqueURI.create(container.getContainerIpAddress(), container.getMappedPort(7711)));
         connection = client.connect().sync();
         retryAfter1Second = AddJobArgs.builder().retry(1, TimeUnit.SECONDS).build();
 

--- a/redis-backed-cache/src/test/java/RedisBackedCacheTest.java
+++ b/redis-backed-cache/src/test/java/RedisBackedCacheTest.java
@@ -22,7 +22,7 @@ public class RedisBackedCacheTest {
 
     @Before
     public void setUp() throws Exception {
-        Jedis jedis = new Jedis(redis.getIpAddress(), redis.getMappedPort(6379));
+        Jedis jedis = new Jedis(redis.getContainerIpAddress(), redis.getMappedPort(6379));
 
         cache = new RedisBackedCache(jedis, "test");
     }


### PR DESCRIPTION
The method `getIpAddress()` is depreciated in favour of `getContainerIpAddress()`. This commit corrects the examples to the latter.