### PR TITLE
Update to Spring Boot 1.5.2

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>1.3.5.RELEASE</version>
+                <version>1.5.2.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -31,20 +31,20 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-redis</artifactId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/spring-boot/src/test/java/com/example/AbstractIntegrationTest.java
+++ b/spring-boot/src/test/java/com/example/AbstractIntegrationTest.java
@@ -2,18 +2,18 @@ package com.example;
 
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.EnvironmentTestUtils;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.testcontainers.containers.GenericContainer;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(value = DemoApplication.class, initializers = AbstractIntegrationTest.Initializer.class)
-@WebIntegrationTest(randomPort = true)
+@SpringBootTest(classes = DemoApplication.class,webEnvironment = WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(initializers = AbstractIntegrationTest.Initializer.class)
 public abstract class AbstractIntegrationTest {
 
     @ClassRule
@@ -29,6 +29,4 @@ public abstract class AbstractIntegrationTest {
         }
     }
 
-    @Value("${local.server.port}")
-    protected int port;
 }

--- a/spring-boot/src/test/java/com/example/DemoApplicationTest.java
+++ b/spring-boot/src/test/java/com/example/DemoApplicationTest.java
@@ -1,18 +1,19 @@
 package com.example;
 
-import org.junit.Test;
-import org.springframework.web.client.RestTemplate;
-
-
 import static org.rnorth.visibleassertions.VisibleAssertions.*;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 
 public class DemoApplicationTest extends AbstractIntegrationTest {
 
-    RestTemplate restTemplate = new RestTemplate();
+    @Autowired
+    TestRestTemplate restTemplate;
 
     @Test
     public void simpleTest() {
-        String fooResource = "http://localhost:" + port + "/foo";
+        String fooResource = "/foo";
 
         info("putting 'bar' to " + fooResource);
         restTemplate.put(fooResource, "bar");


### PR DESCRIPTION
- Uses @SpringBootTest
- Uses TestRestTemplate which is aware of the local.server.port
- spring-boot-starter-redis was renamed to spring-boot-starter-data-rest