### PR TITLE
Added an example using LinkableContainer

### DIFF
--- a/linked-container/pom.xml
+++ b/linked-container/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>testcontainers-java-examples</artifactId>
+        <groupId>org.testcontainers.examples</groupId>
+        <version>NOVERSION</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>linked-container</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>${testcontainers.group}</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>9.4.1212</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.24</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20160810</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/linked-container/src/main/java/com/example/linkedcontainer/RedmineClient.java
+++ b/linked-container/src/main/java/com/example/linkedcontainer/RedmineClient.java
@@ -1,0 +1,32 @@
+package com.example.linkedcontainer;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+/**
+ * A crude, partially implemented Redmine client.
+ */
+public class RedmineClient {
+
+    private String url;
+    private OkHttpClient client;
+
+    public RedmineClient(String url) {
+        this.url = url;
+        client = new OkHttpClient();
+    }
+
+    public int getIssueCount() throws IOException {
+        Request request = new Request.Builder()
+                .url(url + "/issues.json")
+                .build();
+
+        Response response = client.newCall(request).execute();
+        JSONObject jsonObject = new JSONObject(response.body().string());
+        return jsonObject.getInt("total_count");
+    }
+}

--- a/linked-container/src/test/java/com/example/linkedcontainer/RedmineClientTest.java
+++ b/linked-container/src/test/java/com/example/linkedcontainer/RedmineClientTest.java
@@ -25,7 +25,7 @@ public class RedmineClientTest {
             .withEnv("POSTGRES_ENV_POSTGRES_PASSWORD", POSTGRES_PASSWORD);
 
     @Rule
-    public RuleChain chain= RuleChain.outerRule(postgreSQLContainer)
+    public RuleChain chain = RuleChain.outerRule(postgreSQLContainer)
             .around(redmineContainer);
 
     @Test

--- a/linked-container/src/test/java/com/example/linkedcontainer/RedmineClientTest.java
+++ b/linked-container/src/test/java/com/example/linkedcontainer/RedmineClientTest.java
@@ -1,0 +1,41 @@
+package com.example.linkedcontainer;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for RedmineClient.
+ */
+public class RedmineClientTest {
+
+    private static final String POSTGRES_USERNAME = "redmine";
+    private static final String POSTGRES_PASSWORD = "secret";
+
+    private PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer("postgres:9.6.2")
+            .withUsername(POSTGRES_USERNAME)
+            .withPassword(POSTGRES_PASSWORD);
+
+    private RedmineContainer redmineContainer = new RedmineContainer("redmine:3.3.2")
+            .withLinkToContainer(postgreSQLContainer, "postgres")
+            .withEnv("POSTGRES_ENV_POSTGRES_USER", POSTGRES_USERNAME)
+            .withEnv("POSTGRES_ENV_POSTGRES_PASSWORD", POSTGRES_PASSWORD);
+
+    @Rule
+    public RuleChain chain= RuleChain.outerRule(postgreSQLContainer)
+            .around(redmineContainer);
+
+    @Test
+    public void canGetIssueCount() throws Exception {
+        RedmineClient redmineClient = new RedmineClient(
+                redmineContainer.getRedmineUrl());
+
+        assertEquals(
+                "The issue count can be retrieved.",
+                0,
+                redmineClient.getIssueCount());
+    }
+}

--- a/linked-container/src/test/java/com/example/linkedcontainer/RedmineContainer.java
+++ b/linked-container/src/test/java/com/example/linkedcontainer/RedmineContainer.java
@@ -1,0 +1,49 @@
+package com.example.linkedcontainer;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.traits.LinkableContainer;
+import org.testcontainers.containers.wait.Wait;
+
+/**
+ * A linkable Redmine container.
+ */
+public class RedmineContainer<SELF extends RedmineContainer<SELF>> extends GenericContainer<SELF> implements LinkableContainer {
+
+    private static final String IMAGE = "redmine";
+    private static final int REDMINE_PORT = 3000;
+
+    public RedmineContainer() {
+        this(IMAGE + ":latest");
+    }
+
+    public RedmineContainer(String dockerImageName) {
+        super.setDockerImageName(dockerImageName);
+    }
+
+    @Override
+    protected Integer getLivenessCheckPort() {
+        return getMappedPort(REDMINE_PORT);
+    }
+
+    @Override
+    protected void configure() {
+        addExposedPort(REDMINE_PORT);
+        waitingFor(Wait.forHttp("/"));
+    }
+
+    @Override
+    public SELF withEnv(String key, String value) {
+        return super.withEnv(key, value);
+    }
+
+    public SELF withLinkToContainer(LinkableContainer otherContainer, String alias) {
+        addLink(otherContainer, alias);
+        return self();
+    }
+
+    public String getRedmineUrl() {
+        return String.format("http://%s:%d",
+                this.getContainerIpAddress(),
+                this.getMappedPort(REDMINE_PORT));
+    }
+}

--- a/linked-container/src/test/java/com/example/linkedcontainer/RedmineContainer.java
+++ b/linked-container/src/test/java/com/example/linkedcontainer/RedmineContainer.java
@@ -5,7 +5,7 @@ import org.testcontainers.containers.traits.LinkableContainer;
 import org.testcontainers.containers.wait.Wait;
 
 /**
- * A linkable Redmine container.
+ * A Redmine container.
  */
 public class RedmineContainer extends GenericContainer<RedmineContainer> {
 

--- a/linked-container/src/test/java/com/example/linkedcontainer/RedmineContainer.java
+++ b/linked-container/src/test/java/com/example/linkedcontainer/RedmineContainer.java
@@ -7,17 +7,12 @@ import org.testcontainers.containers.wait.Wait;
 /**
  * A linkable Redmine container.
  */
-public class RedmineContainer<SELF extends RedmineContainer<SELF>> extends GenericContainer<SELF> implements LinkableContainer {
+public class RedmineContainer extends GenericContainer<RedmineContainer> {
 
     private static final int REDMINE_PORT = 3000;
 
     public RedmineContainer(String dockerImageName) {
-        super.setDockerImageName(dockerImageName);
-    }
-
-    @Override
-    protected Integer getLivenessCheckPort() {
-        return getMappedPort(REDMINE_PORT);
+        super(dockerImageName);
     }
 
     @Override
@@ -26,14 +21,9 @@ public class RedmineContainer<SELF extends RedmineContainer<SELF>> extends Gener
         waitingFor(Wait.forHttp("/"));
     }
 
-    @Override
-    public SELF withEnv(String key, String value) {
-        return super.withEnv(key, value);
-    }
-
-    public SELF withLinkToContainer(LinkableContainer otherContainer, String alias) {
+    public RedmineContainer withLinkToContainer(LinkableContainer otherContainer, String alias) {
         addLink(otherContainer, alias);
-        return self();
+        return this;
     }
 
     public String getRedmineUrl() {

--- a/linked-container/src/test/java/com/example/linkedcontainer/RedmineContainer.java
+++ b/linked-container/src/test/java/com/example/linkedcontainer/RedmineContainer.java
@@ -9,12 +9,7 @@ import org.testcontainers.containers.wait.Wait;
  */
 public class RedmineContainer<SELF extends RedmineContainer<SELF>> extends GenericContainer<SELF> implements LinkableContainer {
 
-    private static final String IMAGE = "redmine";
     private static final int REDMINE_PORT = 3000;
-
-    public RedmineContainer() {
-        this(IMAGE + ":latest");
-    }
 
     public RedmineContainer(String dockerImageName) {
         super.setDockerImageName(dockerImageName);

--- a/linked-container/src/test/resources/logback-test.xml
+++ b/linked-container/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="org.apache.http" level="WARN"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="org.zeroturnaround.exec" level="WARN"/>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <module>disque-job-queue</module>
         <module>selenium-container</module>
         <module>spring-boot</module>
+        <module>linked-container</module>
     </modules>
 
     <packaging>pom</packaging>


### PR DESCRIPTION
This is an example of how you could use `LinkableContainer` to link Docker containers together. It tests a crude client against the API of the popular project management system Redmine. In order to run a Redmine container it must be linked to a PostgreSQL container.